### PR TITLE
fix unclickable filters on desktop

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -16,7 +16,7 @@ const Header = () => {
     setIsOpen((previous) => !previous);
   };
   return (
-    <header className="sm:flex sm:justify-between sm:items-center sm:px-4 sm:py-2 sticky top-0 bg-whiteSmoke">
+    <header className="sm:flex sm:justify-between sm:items-center sm:px-4 sm:py-2 sticky top-0 bg-whiteSmoke z-20">
       <div className="flex items-center justify-between px-4 py-2 sm:p-0">
         <div>
           <Link href="/">

--- a/components/SearchInput.js
+++ b/components/SearchInput.js
@@ -1,7 +1,7 @@
 import { connectSearchBox } from 'react-instantsearch-dom';
 
 const SearchBox = ({ currentRefinement, isSearchStalled, refine }) => (
-  <div className="sticky top-20">
+  <div className="sticky top-20 z-20 bg-whiteSmoke md:-mx-2 md:px-2">
     <form noValidate action="" role="searct" className="mb-8">
       <div className="relative text-gray-600">
         <span className="absolute inset-y-0 left-0 flex items-center pl-2 text-gray-300">

--- a/pages/index.js
+++ b/pages/index.js
@@ -22,7 +22,7 @@ export default function Home() {
           >
             <Search />
             <div className="block md:flex">
-              <div className="w-full sticky top-36 md:w-1/4 md:mr-4 md:-z-1">
+              <div className="w-full sticky top-36 md:w-1/4 md:mr-4">
                 <div className="md:sticky md:top-44">
                   <Filter />
                 </div>


### PR DESCRIPTION
## Description
This PR makes changes in how `z-index` is used to stack elements on desktop. The fix involves using multiple positive z-index values to avoid sending elements behind parent elements.

## Related Tickets
Fixes #20 