### PR TITLE
Use Sticky Footer instead of overlaying on content 🐛 

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -2,9 +2,10 @@ import Head from 'next/head';
 import Link from 'next/link';
 import Header from './Header';
 
-export default function Layout({ children, isBottom }) {
+export default function Layout({ children }) {
   return (
     <>
+    <div className="flex flex-col min-h-screen ">
       <Head>
         <title>Hire Juniors</title>
         <link rel="preconnect" href="https://fonts.gstatic.com" />
@@ -15,11 +16,9 @@ export default function Layout({ children, isBottom }) {
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png" />
       </Head>
       <Header />
-      <div className="container mx-auto pt-8 sm:pt-16">{children}</div>
+      <div className="container flex-grow mx-auto pt-8 sm:pt-16">{children}</div>
       <footer
-        className={`bottom-0 w-full bg-purplePrimary bg-opacity-30 ${
-          isBottom ? 'absolute' : 'relative'
-        } mt-4`}
+        className={`bottom-0 w-full bg-purplePrimary bg-opacity-30 relative mt-4`}
       >
         <div className="flex justify-between pt-6 px-12 text-md">
           <ul className="text-purplePrimary">
@@ -89,6 +88,7 @@ export default function Layout({ children, isBottom }) {
           </a>
         </div>
       </footer>
+      </div>
     </>
   );
 }

--- a/pages/about.js
+++ b/pages/about.js
@@ -1,7 +1,7 @@
 import Layout from '../components/Layout';
 export default function About() {
   return (
-    <Layout title="About" isBottom={true}>
+    <Layout title="About">
       <h1 className="text-5xl text-center uppercase">About</h1>
       <div className="mt-4 w-3/4 sm:w-1/2 mx-auto text-justify">
         <p className="text-lg">

--- a/pages/getInvolved.js
+++ b/pages/getInvolved.js
@@ -2,7 +2,7 @@ import Layout from '../components/Layout';
 
 export default function GetInvolved() {
   return (
-    <Layout title="Get Involved" isBottom={true}>
+    <Layout title="Get Involved">
       <h1 className="text-5xl text-center uppercase">Get Involved</h1>
       <div className="mt-4 w-3/4 sm:w-1/2 mx-auto">
         <p className="sm:text-lg">

--- a/pages/resources.js
+++ b/pages/resources.js
@@ -20,7 +20,7 @@ export default function Resources({ resources }) {
     return images[0];
   };
   return (
-    <Layout title="Resources" isBottom={false}>
+    <Layout title="Resources">
       <main className="px-4 min-h-screen">
         <h1 className="text-5xl text-center uppercase">Resources</h1>
         <div className="mt-6 grid sm:grid-cols-3 gap-3">


### PR DESCRIPTION
Used flex for sticky footer using article @ https://dev.to/timosville/sticky-footer-using-tailwind-css-225p instead of using relative/absolute . Removed passing isBottom as props as it is not needed now

fixes #19 